### PR TITLE
Update MicrosoftAzure namespace

### DIFF
--- a/src/Gaufrette/Adapter/AzureBlobStorage.php
+++ b/src/Gaufrette/Adapter/AzureBlobStorage.php
@@ -5,10 +5,10 @@ namespace Gaufrette\Adapter;
 use Gaufrette\Adapter;
 use Gaufrette\Util;
 use Gaufrette\Adapter\AzureBlobStorage\BlobProxyFactoryInterface;
-use WindowsAzure\Blob\Models\CreateBlobOptions;
-use WindowsAzure\Blob\Models\CreateContainerOptions;
-use WindowsAzure\Blob\Models\DeleteContainerOptions;
-use WindowsAzure\Blob\Models\ListBlobsOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateBlobOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateContainerOptions;
+use MicrosoftAzure\Storage\Blob\Models\DeleteContainerOptions;
+use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;
 use WindowsAzure\Common\ServiceException;
 
 /**


### PR DESCRIPTION
I think path to namespace aren't up to date. 

Errors of namespace using dummy installation :
- install azure php sdk (microsoft/windowsazure 0.4.3 / azure storage 0.10.1) with composer
- using KnpGaufretteBundle 0.3.0 (gaufrette 0.2.1)
